### PR TITLE
More standard caps behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 | keyboard input |                                   Trigger                                    |
 | :------------: | :--------------------------------------------------------------------------: |
-|   Left shit    |                                    Shift                                     |
-|   Right shit   |                             Toggle case locking                              |
+|      Shift     |                                    Shift                                     |
+| alt+Right shift|                             Toggle case locking                              |
 |      sym       |        Enter numbers and characters (only triggered once, not locked)        |
-| alt+left shit  |                     ctrl+shift(Switch the input method)                      |
+| alt+left shift |                     ctrl+shift(Switch the input method)                      |
 |     alt+b      |                       Change keyboard backlight status                       |
 |      ...       | More custom features can be modified source code implementation, or feedback |
 

--- a/example/BLE_keybord/BLE_keybord.ino
+++ b/example/BLE_keybord/BLE_keybord.ino
@@ -187,7 +187,7 @@ void loop()
         clear_sccreen();
     }
 
-    if (keyPressed(2, 3)) {  //Right Shit  ,Toggle case locking
+    if (keyActive(0, 4) && keyPressed(2, 3)) {  //Alt + Right Shit, Toggle case locking
         case_locking = !case_locking;
     }
 
@@ -337,7 +337,7 @@ void printMatrix()
                     return;
                 }
                 // keys 1,6 and 2,3 are Shift keys, so we want to upper case
-                if (case_locking || keyActive(1, 6)) {
+                if (case_locking || keyActive(1, 6) || keyActive(2, 3)) { // Left or right shift
                     toPrint.toUpperCase();
                 }
 


### PR DESCRIPTION
Change right shift to be a shift key and make alt + right shift into CAPS lock. Get behavior in line with other BlackBerry keyboards.